### PR TITLE
Refactor API & add test coverage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,12 @@
+build:
+  image: python:$$PYTHON_VERSION
+  commands:
+    - pip install -r dev-requirements.txt
+    - flake8 setup.py drone tests
+    - nosetests --with-coverage --cover-package drone -v
+
+matrix:
+  PYTHON_VERSION:
+    - 2.7
+    - 3.4
+    - 3.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Python gunkage
 *.pyc
 *.egg
+*.egg-info
+.coverage
+.tox
 dist
 build
 MANIFEST

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,3 @@
+coverage
+flake8
 nose

--- a/drone/__init__.py
+++ b/drone/__init__.py
@@ -1,1 +1,3 @@
+from . import client, plugin  # noqa
+
 __version__ = '0.1'

--- a/drone/plugin/__init__.py
+++ b/drone/plugin/__init__.py
@@ -1,0 +1,1 @@
+from .input import *  # noqa

--- a/drone/plugin/input.py
+++ b/drone/plugin/input.py
@@ -6,7 +6,7 @@ import sys
 import json
 
 
-def get_plugin_input():
+def get_input():
     """
     Look for input in argv and stdin. De-serialize and return whatever
     we can find.

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,10 +1,9 @@
-import sys
+from drone import plugin
 import copy
+import io
 import json
+import sys
 import unittest
-
-# noinspection PyProtectedMember
-from drone.plugin.input import _get_input_from_argv
 
 
 class ArgvInputTestCase(unittest.TestCase):
@@ -24,7 +23,7 @@ class ArgvInputTestCase(unittest.TestCase):
         # No payload was passed in. We can't do anything with this
         # aside from fail.
         sys.argv = ['some-plugin', '--']
-        self.assertRaises(ValueError, _get_input_from_argv)
+        self.assertRaises(ValueError, plugin.get_input)
 
     def test_valid_payload(self):
         """
@@ -32,6 +31,32 @@ class ArgvInputTestCase(unittest.TestCase):
         """
         test_dict = {'test': 'hello'}
         sys.argv = ['some-plugin', '--', json.dumps(test_dict)]
-        parsed_dict = json.loads(_get_input_from_argv())
+        parsed_dict = plugin.get_input()
         # There should be no differences in the dicts.
         self.assertFalse(set(test_dict.keys()) ^ set(parsed_dict.keys()))
+
+
+class StdinInputTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.stdin = sys.stdin
+
+    def tearDown(self):
+        sys.stdin = self.stdin
+
+    def test_empty_payload(self):
+        """Call the plugin with no input at all.
+        """
+        sys.stdin = io.StringIO()
+        self.assertRaises(ValueError, plugin.get_input)
+
+    def test_valid_payload(self):
+        """Call the plugin with a properly formed payload.
+        """
+        s = u'{"test": "hello"}'
+        sys.stdin = io.StringIO(s)
+        self.assertEqual(plugin.get_input(), json.loads(s))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27, py3, flake8
+
+[testenv]
+commands = {envbindir}/nosetests --with-coverage --cover-package drone -v
+deps = -r{toxinidir}/dev-requirements.txt
+
+[testenv:flake8]
+commands = flake8 setup.py drone tests
+deps = flake8


### PR DESCRIPTION
Thanks for working on this! It seems great so far. I started playing around with it a bit to sketch out the Ansible Tower plugin we discussed on gitter. For better or worse here are my opinionated suggestions!

This seemed a bit more natural to me:

```python
from drone import plugin

args = plugin.get_input()
```

I also added some test coverage and automation scripts.

I tested out the `.drone.yml` using `drone-cli`, i.e. `drone exec`. You could probably get @bradrydzewski to enable CI on his server. It would be nice to try the PyPI publish plugin as well.