### PR TITLE
fix warning E402 in cli/plugin_creator.py

### DIFF
--- a/drone/cli/plugin_creator.py
+++ b/drone/cli/plugin_creator.py
@@ -10,8 +10,6 @@ See :py:func:`prompt_for_variables` for details on the variables and how
 the substitutions work.
 """
 from future import standard_library
-standard_library.install_aliases()
-
 import io
 import os
 import shutil
@@ -21,6 +19,8 @@ import argparse
 import tempfile
 import datetime
 import urllib.request  # noqa
+standard_library.install_aliases()
+
 
 socket.setdefaulttimeout(10.0)
 TEMPLATE_REPO = {


### PR DESCRIPTION
The build was failing when I ran drone exec locally because of the flake8 warnings in drone/cli/plugin_creator.py.

I moved this method call below the imports and now I get a build success.