### PR TITLE
Fix #7 - Add Python 2.7 support

### DIFF
--- a/drone/cli/compat.py
+++ b/drone/cli/compat.py
@@ -1,0 +1,24 @@
+import sys
+
+_ver = sys.version_info
+
+#: Python 2.x
+is_py2 = (_ver[0] == 2)
+
+#: Python 3.x
+is_py3 = (_ver[0] == 3)
+
+
+if is_py2:
+    try:
+        from backports import tempfile
+    except ImportError:
+        print '\nPlease install the required backports.tempfile dependency ' \
+              'via: \npip install backports.tempfile\n\n'
+    from urllib2 import urlopen
+    input = raw_input
+
+elif is_py3:
+    import tempfile
+    from urllib.request import urlopen
+    input = input

--- a/drone/cli/plugin_creator.py
+++ b/drone/cli/plugin_creator.py
@@ -16,9 +16,10 @@ import shutil
 import socket
 import zipfile
 import argparse
-import tempfile
 import datetime
-import urllib.request  # noqa
+
+from .compat import input, tempfile, urlopen
+
 standard_library.install_aliases()
 
 
@@ -45,7 +46,7 @@ def download_and_extract_template(plugin_path):
 
     template_archive_url = \
         "https://github.com/%(repo_owner)s/%(repo_name)s/archive/master.zip"
-    req = urllib.request.urlopen(template_archive_url % TEMPLATE_REPO)
+    req = urlopen(template_archive_url % TEMPLATE_REPO)
     # If the repo ever gets huge, we'll probably want to use a proper tempfile.
     fobj = io.BytesIO(req.read())
     zip_file = zipfile.ZipFile(file=fobj)


### PR DESCRIPTION
Resolve the following compatibility issues in Python 2.7:
- [x] Resolve `AttributeError: 'module' object has no attribute 'TemporaryDirectory'` issue outlined in #7 
- [x] Resolve `input` errors when passing strings not wrapped in quotes.
- [x] Fix `urlopen` reference to use `urllib2`

@gtaylor Can you please take a look at this PR to address #7 and general Python 2.7 support?

Thank you!

Also, are you open to using an import sorting utility like [isort](https://github.com/timothycrosley/isort) ? 